### PR TITLE
Fix: Make datapub and ckan-client-js versions fixed in package d…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "ckanClient": "git+https://github.com/datopian/ckan-client-js.git",
-    "datapub": "git+https://github.com/datopian/datapub.git",
+    "ckanClient": "git+https://github.com/datopian/ckan-client-js.git#bfa869866c3bf50ada2bbc30376e0191c9c263c7",
+    "datapub": "git+https://github.com/datopian/datapub.git#320d2d786ef504157e6b24e7d5a8a67dc4eebdd4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,6 +5373,14 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     crypto-js "^4.0.0"
     frictionless-ckan-mapper-js "^1.0.0"
 
+"ckanClient@git+https://github.com/datopian/ckan-client-js.git#bfa869866c3bf50ada2bbc30376e0191c9c263c7":
+  version "0.2.0"
+  resolved "git+https://github.com/datopian/ckan-client-js.git#bfa869866c3bf50ada2bbc30376e0191c9c263c7"
+  dependencies:
+    axios "^0.19.2"
+    crypto-js "^4.0.0"
+    frictionless-ckan-mapper-js "^1.0.0"
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -6193,31 +6201,14 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-"data.js@git+https://github.com/datopian/data.js.git":
-  version "0.13.0"
-  resolved "git+https://github.com/datopian/data.js.git#953de612a4b958280b60a0cd8d31ee5b3878996b"
-  dependencies:
-    chardet "1.3.0"
-    csv-parse "4.12.0"
-    csv-sniffer "0.1.1"
-    iconv-lite "0.6.2"
-    lodash "4.17.20"
-    mime-types "2.1.27"
-    node-fetch "2.6.1"
-    stream-to-array "2.3.0"
-    stream-to-string "1.2.0"
-    tableschema "1.12.3"
-    url-join "4.0.1"
-    xlsx "0.16.7"
-
-"datapub@git+https://github.com/datopian/datapub.git":
+"datapub@git+https://github.com/datopian/datapub.git#320d2d786ef504157e6b24e7d5a8a67dc4eebdd4":
   version "0.1.0"
-  resolved "git+https://github.com/datopian/datapub.git#159af30c06f889989244519d962b95af6715be0f"
+  resolved "git+https://github.com/datopian/datapub.git#320d2d786ef504157e6b24e7d5a8a67dc4eebdd4"
   dependencies:
     axios "^0.19.2"
     ckanClient "git+https://github.com/datopian/ckan-client-js.git"
-    data.js "git+https://github.com/datopian/data.js.git"
     frictionless-ckan-mapper-js "^1.0.0"
+    frictionless.js "^0.13.2"
     react-scripts "^3.4.3"
     react-table "^7.5.0"
     stream-to-array "^2.3.0"
@@ -7733,6 +7724,25 @@ frictionless-ckan-mapper-js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/frictionless-ckan-mapper-js/-/frictionless-ckan-mapper-js-1.0.0.tgz#856b5bcad12bfbeb72084219fba621aca211700a"
   integrity sha512-/6/5ECgB1sBuKmgbeXHFi4yiSudZszaGUOhlbsqMybGy9IAFwPX8Pu6rqN7aXjTvzWTUJ0bTh2LsNaB9EuPugQ==
+
+frictionless.js@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/frictionless.js/-/frictionless.js-0.13.2.tgz#6a3472050dc7626873f13693ce414eb143429627"
+  integrity sha512-2XXaURUQRK/eDkDeh3TpFnXMitsSn8CNqYf3T+BR5NqDWJ2QuR2owFAdpAdR4cwH4TuuVnEANK4aVHMwsnZXCQ==
+  dependencies:
+    chardet "1.3.0"
+    csv-parse "4.12.0"
+    csv-sniffer "0.1.1"
+    iconv-lite "0.6.2"
+    lodash "4.17.20"
+    mime-types "2.1.27"
+    node-fetch "2.6.1"
+    readable-web-to-node-stream "^2.0.0"
+    stream-to-array "2.3.0"
+    stream-to-string "1.2.0"
+    tableschema "1.12.3"
+    url-join "4.0.1"
+    xlsx "0.16.7"
 
 from2@^2.1.0:
   version "2.3.0"
@@ -13010,6 +13020,11 @@ read-pkg@^3.0.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-web-to-node-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz#751e632f466552ac0d5c440cc01470352f93c4b7"
+  integrity sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA==
 
 readdirp@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
…ependencies

In the dependencies list the versions of datapub and ckan-client-js packages are mount to commit hashes.