### PR TITLE
Fix/ui text tweaks

### DIFF
--- a/src/components/Metadata/index.jsx
+++ b/src/components/Metadata/index.jsx
@@ -22,7 +22,7 @@ const Metadata = ({ metadata, handleChange }) => {
       <div className="metadata-form">
         <div className="metadata-input">
           <label className="metadata-label" htmlFor="title">
-            Title:
+            Title
           </label>
           <input
             className="metadata-input__input"
@@ -35,7 +35,7 @@ const Metadata = ({ metadata, handleChange }) => {
         </div>
         <div className="metadata-input">
           <label className="metadata-label" htmlFor="description">
-            Description:
+            Description
           </label>
           <input
             className="metadata-input__input"
@@ -48,7 +48,7 @@ const Metadata = ({ metadata, handleChange }) => {
         </div>
         <div className="metadata-input">
           <label className="metadata-label" htmlFor="encoding">
-            Encoding:
+            Encoding
           </label>
           <select
             className="metadata-input__input"
@@ -70,7 +70,7 @@ const Metadata = ({ metadata, handleChange }) => {
         </div>
         <div className="metadata-input">
           <label className="metadata-label" htmlFor="format">
-            Format:
+            Format
           </label>
           <select
             className="metadata-input__input"
@@ -97,7 +97,7 @@ const Metadata = ({ metadata, handleChange }) => {
               className="metadata-input"
             >
               <label className="metadata-label" htmlFor="format">
-                {item.label}:
+                {item.label}
               </label>
               <select
                 className="metadata-input__input"

--- a/src/components/SelectSchema/SelectSchema.test.js
+++ b/src/components/SelectSchema/SelectSchema.test.js
@@ -11,9 +11,9 @@ describe("<SelectSchema />", () => {
       <SelectSchema resources={resources} onSchemaSelected={onSchemaSelected} />
     );
 
-    expect(wrapper.contains("Copy schema from existing resource")).toEqual(
-      true
-    );
+    expect(
+      wrapper.contains("Copy metadata information from existing resource")
+    ).toEqual(true);
     expect(wrapper.contains("sample.csv")).toEqual(true);
     expect(wrapper.find("select")).toHaveLength(1);
     expect(wrapper.find("option")).toHaveLength(2);

--- a/src/components/SelectSchema/index.js
+++ b/src/components/SelectSchema/index.js
@@ -13,7 +13,7 @@ const SelectSchema = ({ resources, client, onSchemaSelected }) => {
   return (
     <div className="app-form-field">
       <label className="metadata-label">
-        Copy schema from existing resource
+        Copy metadata information from existing resource
       </label>
       <select
         className="app-form-field-input"


### PR DESCRIPTION
* [x] Text updated from "Copy schema from existing resource" to "Copy metadata information from existing resource"
* [x] Double colon removed (":" instead of "::")

Related issue on Gitlab: 
https://gitlab.com/datopian/clients/nhsbsa-opendata-pm-shared/-/issues/45