### PR TITLE
[x][bug]: fix download url ___ fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -168,6 +168,9 @@ export class ResourceEditor extends React.Component {
         ...ckanResourceCopy,
         id: resourceId,
       };
+      if(!urlName) {
+        ckanResourceCopy.url = `${resource?.name?.toLowerCase()}.${resource?.format?.toLowerCase()}`
+      }
       await client.action("resource_update", ckanResourceCopy);
 
       return (window.location.href = `/dataset/${datasetId}`);


### PR DESCRIPTION
The URL is not passed when the resource is updated, so CKAN by default suffixed the download url with `___`. so if the urlName is not passed, build the url by `resource_name` and the `format`

